### PR TITLE
Hopefully add proper srgb support.

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-tianma-td4310-1080p-video.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-tianma-td4310-1080p-video.dtsi
@@ -71,12 +71,16 @@
 				05 01 00 00 78 00 02 10 00
 		];
 		qcom,mdss-dsi-ce-on-command = [
+				29 01 00 00 00 00 2C CA 1D FC FC FC 00 C1 D3 37 00 3D 0E 13 00 1D FF 00 19 11 00 00 00 3F D5 A1 89 D8 9E 87 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 		];
 		qcom,mdss-dsi-ce-off-command = [
+				29 01 00 00 00 00 2C CA 1C FC FC FC 00 C1 D3 37 00 3D 0E 13 00 1D FF 00 19 11 00 00 00 3F D5 A1 89 D8 9E 87 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 		];
 		qcom,mdss-dsi-srgb-on-command = [
+				29 01 00 00 00 00 2C CA 1D FC FC BC 1F 09 F1 D9 05 D5 EF DC DD 03 F7 E2 F8 05 E9 01 00 2C FF 00 00 FF 00 22 FF 00 FF 00 45 FD 45 FF 00 00 FF 01 2D F6 FF
 		];
 		qcom,mdss-dsi-srgb-off-command = [
+				29 01 00 00 00 00 2C CA 1D FC FC FC 61 FD D4 FA 7F E6 D9 D0 F3 BC A8 94 1D 0E F8 E0 E0 16 FF 00 00 E4 01 23 FF 00 FF 00 50 E3 43 FF 00 00 FF 01 32 E0 FF
 		];
 		qcom,mdss-dsi-cabc-on-command = [
 				15 00 00 00 00 00 02 55 01


### PR DESCRIPTION
Changes are based from [this commit](https://github.com/srfarias/kernel_xiaomi_whyred/commit/cf862ee6114935ece437f4b924ca13f929298c1d). You may ask why add srgb support, it's because you added [fix for srgb after screen turned off](https://github.com/Pzqqt/android_kernel_xiaomi_whyred/commit/1bbcd5aee0dcbd5a7effae7d1bfdec158e53ea03) but never have srgb support to begin with. This commit hopefully add it (or maybe not?, please correct the commit if i'm wrong). Thanks!